### PR TITLE
fix: check strong, em, strike syntax (close: #23)

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -346,9 +346,9 @@ Renderer.markdownTextToEscapeRx = {
 
     link: /!?\[.*\]\(.*\)/,
     reflink: /!?\[.*\]\s*\[([^\]]*)\]/,
-    strong: /__(\S[\s\S]*\h)__|\*\*(\S[\s\S]*\S)\*\*/,
-    em: /_(\S[\s\S]*\S)_|\*(\S[\s\S]*\S)\*/,
-    strikeThrough: /~~(\S[\s\S]*\S)~~/,
+    strong: /__(\S|\S[\s\S]*\S)__|\*\*(\S|\S[\s\S]*\S)\*\*/,
+    em: /_(\S|\S[\s\S]*\S)_|\*(\S|\S[\s\S]*\S)\*/,
+    strikeThrough: /~~(\S|\S[\s\S]*\S)~~/,
     code: /(`+)\s*([\s\S]*?[^`])\s*\1(?!`)/,
 
     verticalBar: /\u007C/,

--- a/test/renderer.spec.js
+++ b/test/renderer.spec.js
@@ -291,6 +291,8 @@ describe('renderer', function() {
         });
 
         it('em, strong', function() {
+            expect(renderer._isNeedEscape('*a*')).toEqual(true);
+            expect(renderer._isNeedEscape('_a_')).toEqual(true);
             expect(renderer._isNeedEscape('*em*')).toEqual(true);
             expect(renderer._isNeedEscape('_em_')).toEqual(true);
             expect(renderer._isNeedEscape('**strong**')).toEqual(true);
@@ -300,6 +302,7 @@ describe('renderer', function() {
         });
 
         it('strikeThrough', function() {
+            expect(renderer._isNeedEscape('~~a~~')).toEqual(true);
             expect(renderer._isNeedEscape('~~true~~')).toEqual(true);
             expect(renderer._isNeedEscape('~~strike through~~')).toEqual(true);
 
@@ -474,16 +477,16 @@ describe('renderer', function() {
 
     it('factory can make renderer that extend from exist renderer', function() {
         var convertedText,
-        renderer = Renderer.factory({
-            'H1, H2, H3, H4, H5, H6': function() {
-                return 'renderer';
-            }
-        }),
-        renderer2 = Renderer.factory(renderer, {
-            'H2': function() {
-                return 'renderer2';
-            }
-        });
+            renderer = Renderer.factory({
+                'H1, H2, H3, H4, H5, H6': function() {
+                    return 'renderer';
+                }
+            }),
+            renderer2 = Renderer.factory(renderer, {
+                'H2': function() {
+                    return 'renderer2';
+                }
+            });
 
         runner = new DomRunner(toDom('<h1>test</h1>'));
         runner.next();


### PR DESCRIPTION
Emphasis, Strong Emphasis, Strikethrough가 `*a*`, `**a**`, `~~a~~` 이와 같이 한글자로 이루어져 있을 때 해당 문법으로 판단하지 못하는 문제 수정

fix nhnent/tui.editor#460