### PR TITLE
fix: list can contain heading (fix #25)

### DIFF
--- a/src/renderer.basic.js
+++ b/src/renderer.basic.js
@@ -150,18 +150,9 @@ var basicRenderer = Renderer.factory({
         return '\n\n' + res + '\n\n';
     },
     'LI H1, LI H2, LI H3, LI H4, LI H5, LI H6': function(node, subContent) {
-        var res = '',
-            headingNumber = parseInt(node.tagName.charAt(1), 10);
+        var headingNumber = parseInt(node.tagName.charAt(1), 10);
 
-        while (headingNumber) {
-            res += '#';
-            headingNumber -= 1;
-        }
-
-        res += ' ';
-        res += subContent;
-
-        return res;
+        return Array(headingNumber + 1).join('#') + ' ' + subContent;
     },
 
     //List

--- a/src/renderer.basic.js
+++ b/src/renderer.basic.js
@@ -149,8 +149,19 @@ var basicRenderer = Renderer.factory({
 
         return '\n\n' + res + '\n\n';
     },
-    'LI H1, LI H2, LI H3, LI H4, LI H5, LI H6': function(node) {
-        return '<' + node.tagName.toLowerCase() + '>' + node.innerHTML + '</' + node.tagName.toLowerCase() + '>';
+    'LI H1, LI H2, LI H3, LI H4, LI H5, LI H6': function(node, subContent) {
+        var res = '',
+            headingNumber = parseInt(node.tagName.charAt(1), 10);
+
+        while (headingNumber) {
+            res += '#';
+            headingNumber -= 1;
+        }
+
+        res += ' ';
+        res += subContent;
+
+        return res;
     },
 
     //List

--- a/test/toMark.lists.spec.js
+++ b/test/toMark.lists.spec.js
@@ -7,7 +7,7 @@ describe('toMark', function() {
         it('Unordered List can be converted', function() {
             var htmlStr = [
                 '<ul>',
-                    '<li>TEST</li>',
+                '<li>TEST</li>',
                 '</ul>'
             ].join('');
 
@@ -17,7 +17,7 @@ describe('toMark', function() {
         it('Ordered List can be converted', function() {
             var htmlStr = [
                 '<ol>',
-                    '<li>TEST</li>',
+                '<li>TEST</li>',
                 '</ol>'
             ].join('');
 
@@ -27,12 +27,12 @@ describe('toMark', function() {
         it('Nested List can be converted', function() {
             var htmlStr = [
                 '<ol>',
-                    '<li>DEPTH1',
-                        '<ul>',
-                            '<li>DEPTH2-1</li>',
-                            '<li>DEPTH2-2</li>',
-                        '</ul>',
-                    '</li>',
+                '<li>DEPTH1',
+                '<ul>',
+                '<li>DEPTH2-1</li>',
+                '<li>DEPTH2-2</li>',
+                '</ul>',
+                '</li>',
                 '</ol>'
             ].join('');
 
@@ -42,42 +42,42 @@ describe('toMark', function() {
         it('Multiple Nesting', function() {
             var htmlStr = [
                 '<ol>',
-                    '<li>DEPTH1',
-                        '<ul>',
-                            '<li>DEPTH2',
-                                '<ul>',
-                                    '<li>DEPTH3',
-                                        '<ul>',
-                                            '<li>DEPTH4</li>',
-                                        '</ul>',
-                                     '</li>',
-                                '</ul>',
-                            '</li>',
-                        '</ul>',
-                    '</li>',
+                '<li>DEPTH1',
+                '<ul>',
+                '<li>DEPTH2',
+                '<ul>',
+                '<li>DEPTH3',
+                '<ul>',
+                '<li>DEPTH4</li>',
+                '</ul>',
+                '</li>',
+                '</ul>',
+                '</li>',
+                '</ul>',
+                '</li>',
                 '</ol>'
             ].join('');
 
             expect(toMark(htmlStr)).toEqual('1. DEPTH1\n    * DEPTH2\n        * DEPTH3\n            * DEPTH4');
         });
 
-        it('if haadings are nested in li, convert to inline html', function() {
+        it('list can contain heading', function() {
             var htmlStr = [
                 '<ul>',
-                    '<li>',
-                        '<h1>nested heading</h1>',
-                    '</li>',
+                '<li>',
+                '<h1>nested heading</h1>',
+                '</li>',
                 '</ul>'
             ].join('');
 
-            expect(toMark(htmlStr)).toEqual('* <h1>nested heading</h1>');
+            expect(toMark(htmlStr)).toEqual('* # nested heading');
         });
 
         it('empty list have blank text', function() {
             var htmlStr = [
                 '<ul>',
-                    '<li></li>',
-                    '<li>2</li>',
+                '<li></li>',
+                '<li>2</li>',
                 '</ul>'
             ].join('');
 
@@ -88,9 +88,9 @@ describe('toMark', function() {
             var htmlStr = [
                 '<p>p</p>',
                 '<ul>',
-                    '<li><p>1</p></li>',
-                    '<li><p>2</p></li>',
-                    '<li>3</li>',
+                '<li><p>1</p></li>',
+                '<li><p>2</p></li>',
+                '<li>3</li>',
                 '</ul>',
                 '<p>p2</p>'
             ].join('');


### PR DESCRIPTION
fix https://github.com/nhn/to-mark/issues/25, https://github.com/nhn/tui.editor/issues/500

A list item can contain a heading (https://spec.commonmark.org/0.29/#example-270)

```html
<ul>
<li>
<h1>Foo</h1>
</li>
</ul>
```

convert

```md
* # Foo
```
