### PR TITLE
fix: prevent image inside link from being escaped 

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -334,7 +334,7 @@ Renderer.prototype.escapeTextForLink = function(text) {
     var imageSyntaxRanges = [];
     var result = FIND_MARKDOWN_IMAGE_SYNTAX_RX.exec(text);
 
-    while (result !== null) {
+    while (result) {
         imageSyntaxRanges.push([result.index, result.index + result[0].length]);
         result = FIND_MARKDOWN_IMAGE_SYNTAX_RX.exec(text);
     }

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -14,7 +14,9 @@ var FIND_LEAD_SPACE_RX = /^\u0020/,
     //find characters that need escape
     FIND_CHAR_TO_ESCAPE_RX = /[~>()*{}\[\]_`+-.!#|]/g,
     // find characters to be escaped in links or images
-    FIND_CHAR_TO_ESCAPE_IN_LINK_RX = /[\[\]\(\)<>]/g;
+    FIND_CHAR_TO_ESCAPE_IN_LINK_RX = /[\[\]]/g,
+    // find markdown image syntax
+    FIND_MARKDOWN_IMAGE_SYNTAX_RX = /!\[.*\]\(.*\)/g;
 
 var TEXT_NODE = 3;
 
@@ -329,8 +331,20 @@ Renderer.prototype.escapeText = function(text) {
  * @returns {string} - processed text
  */
 Renderer.prototype.escapeTextForLink = function(text) {
-    return text.replace(FIND_CHAR_TO_ESCAPE_IN_LINK_RX, function(matched) {
-        return '\\' + matched;
+    var imageSyntaxRanges = [];
+    var result = FIND_MARKDOWN_IMAGE_SYNTAX_RX.exec(text);
+
+    while (result !== null) {
+        imageSyntaxRanges.push([result.index, result.index + result[0].length]);
+        result = FIND_MARKDOWN_IMAGE_SYNTAX_RX.exec(text);
+    }
+
+    return text.replace(FIND_CHAR_TO_ESCAPE_IN_LINK_RX, function(matched, offset) {
+        var isDelimiter = imageSyntaxRanges.some(function(range) {
+            return offset > range[0] && offset < range[1];
+        });
+
+        return isDelimiter ? matched : '\\' + matched;
     });
 };
 

--- a/test/renderer.basic.spec.js
+++ b/test/renderer.basic.spec.js
@@ -98,7 +98,7 @@ describe('basicRenderer', function() {
         });
 
         it('link which has characters for markdown link syntax', function() {
-            expect(getMarkdownText('<a href="#head"></a>', 'char []()<> to escape')).toEqual('[char \\[\\]\\(\\)\\<\\> to escape](#head)');
+            expect(getMarkdownText('<a href="#head"></a>', 'char [] to escape')).toEqual('[char \\[\\] to escape](#head)');
         });
 
         it('image', function() {
@@ -114,7 +114,7 @@ describe('basicRenderer', function() {
         });
 
         it('image which has characters for markdown image syntax', function() {
-            expect(getMarkdownText('<img src="#head" alt="char []()<> to escape"></a>')).toEqual('![char \\[\\]\\(\\)\\<\\> to escape](#head)');
+            expect(getMarkdownText('<img src="#head" alt="char [] to escape"></a>')).toEqual('![char \\[\\] to escape](#head)');
         });
 
         it('strong, b', function() {

--- a/test/toMark.spec.js
+++ b/test/toMark.spec.js
@@ -35,16 +35,16 @@ describe('toMark', function() {
 
     it('should not escape image syntax inside link syntax', function() {
         expect(toMark(
-          '<a href="url"><img src="src" alt="alt" /></a>')).toEqual(
-          '[![alt](src)](url)'
+            '<a href="url"><img src="src" alt="alt" /></a>')).toEqual(
+            '[![alt](src)](url)'
         );
         expect(toMark(
-          '<a href="url"><img src="src" alt="alt" /><img src="src2" alt="alt2" /></a>')).toEqual(
-          '[![alt](src)![alt2](src2)](url)'
+            '<a href="url"><img src="src" alt="alt" /><img src="src2" alt="alt2" /></a>')).toEqual(
+            '[![alt](src)![alt2](src2)](url)'
         );
         expect(toMark(
-          '<a href="url"><img src="src" alt="alt" />Text<img src="src2" alt="alt2" /></a>')).toEqual(
-          '[![alt](src)Text![alt2](src2)](url)'
+            '<a href="url"><img src="src" alt="alt" />Text<img src="src2" alt="alt2" /></a>')).toEqual(
+            '[![alt](src)Text![alt2](src2)](url)'
         );
     });
 

--- a/test/toMark.spec.js
+++ b/test/toMark.spec.js
@@ -27,6 +27,27 @@ describe('toMark', function() {
         expect(toMark('<b>|go ro Work|</b>')).toEqual('**\\|go ro Work\\|**');
     });
 
+    it('should escape [, ] inside link syntax', function() {
+        expect(toMark('<a href="url">text[</a>')).toEqual('[text\\[](url)');
+        expect(toMark('<a href="url">text]</a>')).toEqual('[text\\]](url)');
+        expect(toMark('<a href="url">[text]</a>')).toEqual('[\\[text\\]](url)');
+    });
+
+    it('should not escape image syntax inside link syntax', function() {
+        expect(toMark(
+          '<a href="url"><img src="src" alt="alt" /></a>')).toEqual(
+          '[![alt](src)](url)'
+        );
+        expect(toMark(
+          '<a href="url"><img src="src" alt="alt" /><img src="src2" alt="alt2" /></a>')).toEqual(
+          '[![alt](src)![alt2](src2)](url)'
+        );
+        expect(toMark(
+          '<a href="url"><img src="src" alt="alt" />Text<img src="src2" alt="alt2" /></a>')).toEqual(
+          '[![alt](src)Text![alt2](src2)](url)'
+        );
+    });
+
     it('markdown text\'s EOL FOL newline characters should be removed', function() {
         expect(toMark('<h1>Hello World</h1>')).toEqual('# Hello World');
         expect(toMark('<h1>Hello World</h1><br />')).toEqual('# Hello World');


### PR DESCRIPTION
fix: https://github.com/nhn/tui.editor/issues/633

- A valid Image syntax inside link syntax shouldn't be escaped.
- `(`, `)`, `<`, `>` inside link syntax don't need to be escaped.