### PR TITLE
fix: reset regexp object state when invoking test

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -355,7 +355,7 @@ Renderer.prototype.escapeTextForLink = function(text) {
  * @returns {string} processed text
  */
 Renderer.prototype.escapeTextHtml = function(text) {
-    return text.replace(Renderer.markdownTextToEscapeHtmlRx, function(matched) {
+    return text.replace(new RegExp(Renderer.markdownTextToEscapeHtmlRx.source, 'g'), function(matched) {
         return '\\' + matched;
     });
 };
@@ -369,7 +369,7 @@ Renderer.prototype.escapeTextHtml = function(text) {
  * @returns {string} processed text
  */
 Renderer.prototype.escapeTextBackSlash = function(text) {
-    return text.replace(Renderer.markdownTextToEscapeBackSlashRx, function(matched) {
+    return text.replace(new RegExp(Renderer.markdownTextToEscapeBackSlashRx.source, 'g'), function(matched) {
         return '\\' + matched;
     });
 };
@@ -380,7 +380,7 @@ Renderer.prototype.escapeTextBackSlash = function(text) {
  * @returns {string} escaped text
  */
 Renderer.prototype.escapePairedCharacters = function(text) {
-    return text.replace(Renderer.markdownTextToEscapePairedCharsRx, function(matched) {
+    return text.replace(new RegExp(Renderer.markdownTextToEscapePairedCharsRx.source, 'g'), function(matched) {
         return '\\' + matched;
     });
 };
@@ -403,11 +403,11 @@ Renderer.markdownTextToEscapeRx = {
     codeblockTildes: /^(~{3,})/
 };
 
-Renderer.markdownTextToEscapeHtmlRx = /<([a-zA-Z_][a-zA-Z0-9\-\._]*)(\s|[^\\/>])*\/?>|<(\/)([a-zA-Z_][a-zA-Z0-9\-\._]*)\s*\/?>|<!--[^-]+-->|<([a-zA-Z_][a-zA-Z0-9\-\.:/]*)>/g;
+Renderer.markdownTextToEscapeHtmlRx = /<([a-zA-Z_][a-zA-Z0-9\-\._]*)(\s|[^\\/>])*\/?>|<(\/)([a-zA-Z_][a-zA-Z0-9\-\._]*)\s*\/?>|<!--[^-]+-->|<([a-zA-Z_][a-zA-Z0-9\-\.:/]*)>/;
 
-Renderer.markdownTextToEscapeBackSlashRx = /\\[!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~\\]/g;
+Renderer.markdownTextToEscapeBackSlashRx = /\\[!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~\\]/;
 
-Renderer.markdownTextToEscapePairedCharsRx = /[*_~`]/g;
+Renderer.markdownTextToEscapePairedCharsRx = /[*_~`]/;
 
 Renderer.prototype._isNeedEscape = function(text) {
     var res = false;

--- a/test/renderer.spec.js
+++ b/test/renderer.spec.js
@@ -309,7 +309,7 @@ describe('renderer', function() {
         });
     });
 
-    it('_isNeedEscapeHtml() can check passed text is needed escape or not', function() {
+    describe('_isNeedEscapeHtml() can check passed text is needed escape or not', function() {
         var renderer;
 
         beforeEach(function() {

--- a/test/toMark.spec.js
+++ b/test/toMark.spec.js
@@ -11,7 +11,7 @@ describe('toMark', function() {
 
     it('child elements of an element which has \'data-tomark-pass\' should be converted', function() {
         expect(toMark('<b data-tomark-pass>Hello <s>World</s></b>')).toBe('<b>Hello ~~World~~</b>');
-        expect(toMark('<b id="a1" class="custom" data-tomark-pass>Hello <s>World</s></b>')).toBe('<b id="a1" class="custom">Hello ~~World~~</b>');
+        expect(toMark('<b class="custom" data-tomark-pass>Hello <s>World</s></b>')).toBe('<b class="custom">Hello ~~World~~</b>');
     });
 
     it('if pass empty string or falsy object return empty string', function() {


### PR DESCRIPTION
- As invoking `test()` of RegExp object with g(global) option change inner state(`lastIndex`) of the object, the result of `test()` is inconsistent.
- To fix this, create cached RegExp objects without global option and create new RegExp objects whenever `replace()` uses them.